### PR TITLE
Fix Message not received with long delay

### DIFF
--- a/Python/boot.py
+++ b/Python/boot.py
@@ -13,7 +13,7 @@ import gc
 from wifi import WifiConnector
 from mqtt import MQTTClient, MQTTException  # mqtt module and its exceptions
 from my_secrets import mqtt_credentials  # secrets is not pushed to avoid having WIFI access on github
-from machine import Pin, reset
+from machine import Pin, reset, unique_id
 from time import sleep_ms
 '''
 ##################################################################################
@@ -32,7 +32,7 @@ MQTT_SERVER = "io.adafruit.com"
 MQTT_PORT = 1883
 MQTT_USER = mqtt_credentials['username']
 MQTT_KEY = mqtt_credentials['key']
-MQTT_CLIENT_ID = "Greeny_paralex"  # Can be anything TODO: should be made unique
+MQTT_CLIENT_ID = "Greeny_paralex" + unique_id()
 '''
 ##################################################################################
 ##################################################################################
@@ -86,6 +86,7 @@ try:
 
     # establish connection to MQTT server
     mqtt_client.connect()           # connect to mqtt
+    sleep_ms(100)
     mqtt_client.publish(topic="paralex/feeds/last-will", msg="0") # publish a connection status to the adafruit interface
     
 

--- a/Python/main.py
+++ b/Python/main.py
@@ -14,7 +14,7 @@ import custom_exceptions as ce  # custom exceptions for error handling
 
 from boot import blink, mqtt_client
 from analog_sensor import AnalogSensor      # Analog sensor module which provides an extra abstraction layer and more control over the analog sensors
-from machine import Pin, reset          # micropython library for pin access      
+from machine import Pin, reset, reset_cause          # micropython library for pin access      
 from time import sleep            # time functions
 from my_secrets import mqtt_feeds    # secret file with credentials
 '''
@@ -27,7 +27,7 @@ Global Variables and Objects
 ##################################################################################
 '''
 # delays
-DELAY = 900 # delay in s between each readings -> 15 minutes
+DELAY = 1800 # delay in s between each readings -> 30 minutes
 BLINK_DELAY_UNKNOWN_ERROR = 500 # in ms define the blink delay for unkown errors
 BLINK_DELAY_SENSOR_CONF_ERROR = 100 # blink delay for analog sensor configuration error
 BLINK_DELAY_SENSOR_READING_ERROR = 1000
@@ -93,25 +93,26 @@ except Exception as e:
 
 while True:
     try: 
+        print("Reset cause: {}".format(reset_cause()))
         dht11_sensor.measure()
         current_temperature = dht11_sensor.temperature()
-        mqtt_client.publish(topic=MQTT_AMBIENT_TEMP_FEED,msg=str(current_temperature))
+        mqtt_client.publish(topic=MQTT_AMBIENT_TEMP_FEED,msg=str(current_temperature),qos=1)
         blink(BLINK_DELAY_SENDING_DATA)
 
         current_humidity = dht11_sensor.humidity()
-        mqtt_client.publish(topic=MQTT_AMBIENT_HUMI_FEED,msg=str(current_humidity))
+        mqtt_client.publish(topic=MQTT_AMBIENT_HUMI_FEED,msg=str(current_humidity),qos=1)
         blink(BLINK_DELAY_SENDING_DATA)
 
         percentage_darkness = light_sensor.get_percentage_data()
         # We calculate the complementary percentage because it is more intuitive to think about % of light instead of darkness
         percentage_light = 100 - percentage_darkness 
-        mqtt_client.publish(topic=MQTT_AMBIENT_LIGHT,msg=str(percentage_light))
+        mqtt_client.publish(topic=MQTT_AMBIENT_LIGHT,msg=str(percentage_light),qos=1)
         blink(BLINK_DELAY_SENDING_DATA)
 
         percentage_dryness = soil_sensor.get_percentage_data()
         # We calculate the complementary percentage because it is more intuitive to think about % of humidity instead of dryness
         percentage_moist = 100 - percentage_dryness 
-        mqtt_client.publish(topic=MQTT_SOIL_MOISTURE_FEED, msg=str(percentage_moist))
+        mqtt_client.publish(topic=MQTT_SOIL_MOISTURE_FEED, msg=str(percentage_moist),qos=1)
         blink(BLINK_DELAY_SENDING_DATA)
 
         # Print info into the console


### PR DESCRIPTION
# Description:
Set QOS at 1 so that if message not sent, reset board with exception handling
Delay at 30 minutes instead of 15
Added unique id to mqtt user

# Details
It seems that when trying to send the message after 15 minutes, the broker does not receive it. 
We set QOS to 1 to wait for an answer from the broker. This seems to trigger a reset of the board via exception (needs to be confirmed). The reset recreates the connections and send the value. 
If this fixes the issue, there is still something to investigate on what happens when sending the message after 15 minutes. 

# Screenshots 
**Data received for ambient humidity**
<img width="240" alt="Screenshot 2023-06-30 at 11 27 56" src="https://github.com/alrapal/greeny/assets/71485862/884494f2-2bf1-4028-874b-f06dee53233d">
---
**Connection ping received**
<img width="197" alt="Screenshot 2023-06-30 at 11 28 09" src="https://github.com/alrapal/greeny/assets/71485862/0b4cb012-1106-4c88-bc29-f9e19eb0d427">

fix #16 