### PR TITLE
Adapt for TIG stack

### DIFF
--- a/Python/boot.py
+++ b/Python/boot.py
@@ -28,11 +28,12 @@ Global Variables and Objects
 built_in_led = Pin("LED", Pin.OUT)
 
 # MQTT parameters
-MQTT_SERVER = "io.adafruit.com"
-MQTT_PORT = 1883
+MQTT_SERVER = mqtt_credentials['server']
+MQTT_PORT = mqtt_credentials['port']
 MQTT_USER = mqtt_credentials['username']
 MQTT_KEY = mqtt_credentials['key']
-MQTT_CLIENT_ID = "Greeny_paralex" + unique_id()
+MQTT_CLIENT_ID = "Greeny_paralex_pico_w" + str(unique_id())
+MQTT_KA = 900
 '''
 ##################################################################################
 ##################################################################################
@@ -71,7 +72,7 @@ Functions section
 try: 
     # Instanciate the objects that will allow wifi and mqtt manipulations
     wifi_connector = WifiConnector()
-    mqtt_client = MQTTClient(client_id=MQTT_CLIENT_ID, server=MQTT_SERVER, port=MQTT_PORT, user=MQTT_USER, password=MQTT_KEY)
+    mqtt_client = MQTTClient(client_id=MQTT_CLIENT_ID, server=MQTT_SERVER, port=MQTT_PORT, user=MQTT_USER, password=MQTT_KEY, keepalive=MQTT_KA)
     mqtt_client.set_callback(sub_cb) # sets the method to use on message received. We do not subscribe to any channel so this will not be used. 
 
     # connects to wifi 

--- a/Python/main.py
+++ b/Python/main.py
@@ -12,9 +12,10 @@ import dht                # DHT library provided by micropython
 import gc                 # garbage collector for memory management
 import custom_exceptions as ce  # custom exceptions for error handling
 
-from boot import blink, mqtt_client
+from ujson import dumps
+from boot import blink, mqtt_client, MQTT_CLIENT_ID
 from analog_sensor import AnalogSensor      # Analog sensor module which provides an extra abstraction layer and more control over the analog sensors
-from machine import Pin, reset, reset_cause          # micropython library for pin access      
+from machine import Pin, reset, reset_cause      # micropython library for pin access      
 from time import sleep            # time functions
 from my_secrets import mqtt_feeds    # secret file with credentials
 '''
@@ -27,7 +28,7 @@ Global Variables and Objects
 ##################################################################################
 '''
 # delays
-DELAY = 1800 # delay in s between each readings -> 30 minutes
+DELAY = 900 # delay in s between each readings -> 15 minutes
 BLINK_DELAY_UNKNOWN_ERROR = 500 # in ms define the blink delay for unkown errors
 BLINK_DELAY_SENSOR_CONF_ERROR = 100 # blink delay for analog sensor configuration error
 BLINK_DELAY_SENSOR_READING_ERROR = 1000
@@ -45,7 +46,7 @@ MQTT_AMBIENT_TEMP_FEED = mqtt_feeds['ambient_temperature']
 MQTT_AMBIENT_HUMI_FEED = mqtt_feeds['ambient_humidity']
 MQTT_AMBIENT_LIGHT = mqtt_feeds['ambient_light']
 MQTT_SOIL_MOISTURE_FEED = mqtt_feeds['soil_moisture']
-
+MQTT_FEED = MQTT_CLIENT_ID
 # Boundaries for Analog sensors:
 MAX_SOIL = 43500 # Correspond to the reading obtained when sensor in the air and dry
 MIN_SOIL = 13000 # Corresponds to the reading obtained when sensor was emegred in water. 
@@ -94,27 +95,51 @@ except Exception as e:
 while True:
     try: 
         print("Reset cause: {}".format(reset_cause()))
+
         dht11_sensor.measure()
         current_temperature = dht11_sensor.temperature()
-        mqtt_client.publish(topic=MQTT_AMBIENT_TEMP_FEED,msg=str(current_temperature),qos=1)
+        data = {
+            'temperature': current_temperature
+        }
+
+        json_data = dumps(data)
+        print(json_data)
+        mqtt_client.publish(topic=MQTT_AMBIENT_TEMP_FEED,msg=json_data,qos=1)
         blink(BLINK_DELAY_SENDING_DATA)
 
         current_humidity = dht11_sensor.humidity()
-        mqtt_client.publish(topic=MQTT_AMBIENT_HUMI_FEED,msg=str(current_humidity),qos=1)
+        data = {
+            'humidity': current_humidity
+        }
+
+        json_data = dumps(data)
+        print(json_data)
+        mqtt_client.publish(topic=MQTT_AMBIENT_HUMI_FEED,msg=json_data,qos=1)
         blink(BLINK_DELAY_SENDING_DATA)
 
         percentage_darkness = light_sensor.get_percentage_data()
         # We calculate the complementary percentage because it is more intuitive to think about % of light instead of darkness
         percentage_light = 100 - percentage_darkness 
-        mqtt_client.publish(topic=MQTT_AMBIENT_LIGHT,msg=str(percentage_light),qos=1)
+        data = {
+            'light': percentage_light
+        }
+
+        json_data = dumps(data)
+        print(json_data)
+        mqtt_client.publish(topic=MQTT_AMBIENT_LIGHT,msg=json_data,qos=1)
         blink(BLINK_DELAY_SENDING_DATA)
 
         percentage_dryness = soil_sensor.get_percentage_data()
         # We calculate the complementary percentage because it is more intuitive to think about % of humidity instead of dryness
         percentage_moist = 100 - percentage_dryness 
-        mqtt_client.publish(topic=MQTT_SOIL_MOISTURE_FEED, msg=str(percentage_moist),qos=1)
+        data = {
+            'moist': percentage_moist
+        }
+        json_data = dumps(data)
+        print(json_data)
+        mqtt_client.publish(topic=MQTT_SOIL_MOISTURE_FEED, msg=json_data,qos=1)
         blink(BLINK_DELAY_SENDING_DATA)
-
+        
         # Print info into the console
         print("###################################")
         print("Available memory: ", gc.mem_free())


### PR DESCRIPTION
# Description
Changed boot and main to use personal MQTT broker credentials. 
MQTT messages are then subscribed by Telegraf and written in an Influx database. The data is visualised using Graphana.
The TIG stack is within a docker compose. 
More info in link in #7 
Changed keep alive for 900 to avoid known bug with mosquitto and corresponds to the frequency when the data is alive. 
If set to 0, the broker refuse the connection.[GitHub Issue](https://github.com/eclipse/mosquitto/issues/2117)

The TIG docker compose will be added later to the repo. 
related to #7 